### PR TITLE
Work with SWIG 3.0.

### DIFF
--- a/SWIG_CGAL/common.i
+++ b/SWIG_CGAL/common.i
@@ -37,7 +37,7 @@
       }
     }
   %}
-  #always load CGAL_Java to get JNI_OnLoad called
+  // always load CGAL_Java to get JNI_OnLoad called
   SWIG_CGAL_add_java_loadLibrary_CGAL_Java()  
 %enddef
   


### PR DESCRIPTION
Starting with SWIG 3.0, all unknown SWIG preprocessor directives will start throwing an error.  It looks like there was a comment that used `#` instead of `//`.  This was silently ignored in SWIG 2.0.  See https://github.com/swig/swig/issues/217.