### PR TITLE
Fix underlinking to Boost libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option ( LINK_PYTHON_LIBRARY "Link against python libraries" ON )
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/SWIG_CGAL_Macros.cmake)
 
+find_package(Boost COMPONENTS system thread REQUIRED)
 find_package(CGAL QUIET COMPONENTS ImageIO)
 find_package(SWIG REQUIRED)
 option( BUILD_PYTHON "Build Python bindings" ON )

--- a/cmake/Modules/SWIG_CGAL_Macros.cmake
+++ b/cmake/Modules/SWIG_CGAL_Macros.cmake
@@ -19,7 +19,7 @@ MACRO(ADD_SWIG_CGAL_LIBRARY libname)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${COMMON_LIBRARIES_PATH}")
   EXTRACT_CPP_AND_LIB_FILES(${ARGN}) 
   add_library(${libname} SHARED ${object_files})
-  target_link_libraries(${libname} ${libstolinkwith})
+  target_link_libraries(${libname} ${libstolinkwith} ${Boost_LIBRARIES})
 ENDMACRO()
 
 MACRO(ADD_SWIG_CGAL_JAVA_MODULE packagename)


### PR DESCRIPTION
These bindings use Boost but don't link against it, and now when I try to use the bindings, running a program gives link errors.  For example:

    khumba@mikasa /kh/files/dev/projects/cgal-swig-bindings.git/examples/java 1 $ javac -classpath /kh/files/dev/projects/cgal-swig-bindings.git/build/build-java AABB_triangle_3_example.java
    Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
    khumba@mikasa /kh/files/dev/projects/cgal-swig-bindings.git/examples/java 0 $ LD_LIBRARY_PATH=/kh/files/dev/projects/cgal-swig-bindings.git/build/build-java/lib java -classpath .:/kh/files/dev/projects/cgal-swig-bindings.git/build/build-java AABB_triangle_3_example
    Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
    Native code library CGAL_AABB_tree failed to load.
    java.lang.UnsatisfiedLinkError: /kh/files/dev/projects/cgal-swig-bindings.git/build/build-java/lib/libCGAL_AABB_tree.so: /kh/files/dev/projects/cgal-swig-bindings.git/build/build-java/lib/libCGAL_AABB_tree.so: undefined symbol: _ZN5boost6system16generic_categoryEv
    Exception in thread "main" java.lang.UnsatisfiedLinkError: /kh/files/dev/projects/cgal-swig-bindings.git/build/build-java/lib/libCGAL_AABB_tree.so: /kh/files/dev/projects/cgal-swig-bindings.git/build/build-java/lib/libCGAL_AABB_tree.so: undefined symbol: _ZN5boost6system16generic_categoryEv
            at java.lang.ClassLoader$NativeLibrary.load(Native Method)
            at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
            at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1857)
            at java.lang.Runtime.loadLibrary0(Runtime.java:870)
            at java.lang.System.loadLibrary(System.java:1122)
            at CGAL.AABB_tree.CGAL_AABB_treeJNI.<clinit>(CGAL_AABB_treeJNI.java:18)
            at CGAL.AABB_tree.AABB_tree_Triangle_3_soup.<init>(AABB_tree_Triangle_3_soup.java:43)
            at AABB_triangle_3_example.main(AABB_triangle_3_example.java:22)

A similar error occurs when I try to load the bindings in Scilab (from my forked repo):

    ...
    Link failed for dynamic library '/kh/files/dev/projects/cgal-swig-bindings.git/build/SWIG_CGAL/Kernel/libCGAL_Kernel_Scilab.so'.
    An error occurred: /kh/files/dev/projects/cgal-swig-bindings.git/build/lib/libCGAL_Kernel_cpp.so: undefined symbol: _ZN5boost6detail12set_tss_dataEPKvNS_10shared_ptrINS0_20tss_cleanup_functionEEEPvb

This patch fixes these errors.