### PR TITLE
Include std_vector.i in CGAL_Box_intersection_d

### DIFF
--- a/SWIG_CGAL/Box_intersection_d/CGAL_Box_intersection_d.i
+++ b/SWIG_CGAL/Box_intersection_d/CGAL_Box_intersection_d.i
@@ -39,6 +39,7 @@ SWIG_CGAL_package_common()
 
 
 %include "std_pair.i"
+%include "std_vector.i"
 SWIG_CGAL_declare_identifier_of_template_class(Pair_of_int,std::pair<int,int>)
 
 SWIG_CGAL_set_as_java_iterator(SWIG_CGAL_Iterator,Pair_of_int,)


### PR DESCRIPTION
Fixes build on windows:
```
[ 89%] Building CXX object SWIG_CGAL/Box_intersection_d/CMakeFiles/_CGAL_Box_intersection_d.dir/__/__/build-python/CGAL/CGAL_Box_intersection_dPYTHON_wrap.cxx.obj
CGAL_Box_intersection_dPYTHON_wrap.cxx
W:\Miniconda\conda-bld\cgal-feedstock_1481640999917\work\CGAL-4.9\cgal-swig-bindings\build\build-python\CGAL\CGAL_Box_intersection_dPYTHON_wrap.cxx(3755): error C2976: 'std::vector': too few template arguments
W:\Miniconda\conda-bld\cgal-feedstock_1481640999917\_b_env\Library\include\boost/detail/container_fwd.hpp(135): note: see declaration of 'std::vector'
W:\Miniconda\conda-bld\cgal-feedstock_1481640999917\work\CGAL-4.9\cgal-swig-bindings\build\build-python\CGAL\CGAL_Box_intersection_dPYTHON_wrap.cxx(3755): error C2955: 'std::vector': use of class template requires template argument list
```