### PR TITLE
Allow to build PMP bindings against CGAL 4.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ if ( CGAL_FOUND )
     add_subdirectory(SWIG_CGAL/Box_intersection_d)
     add_subdirectory(SWIG_CGAL/Advancing_front_surface_reconstruction)
 
-    if ("${CGAL_MAJOR_VERSION}" STRGREATER "3" AND "${CGAL_MINOR_VERSION}" STRGREATER "6")
+    if (CGAL_VERSION VERSION_GREATER 3.6)
       find_package(Eigen3 3.2.0) #(requires 3.2.0 or greater)
       if (EIGEN3_FOUND)
         include( ${EIGEN3_USE_FILE} )


### PR DESCRIPTION
STRGREATER uses the lexicographic order, this breaks with latest 4.10 as "6">"10"