### PR TITLE
Shape_detection_example: Loading the points the Python way

### DIFF
--- a/examples/python/Shape_detection_example.py
+++ b/examples/python/Shape_detection_example.py
@@ -8,7 +8,20 @@ import os
 datadir = os.environ.get('DATADIR', '../data')
 datafile = datadir+'/cube.pwn'
 
-points = Point_set_3(datafile)
+# Creating an empty set of points and their normals
+points = Point_set_3()
+
+point_normal_file = open(datafile, "rb")
+point_normal_lines = point_normal_file.readlines()
+
+for line in point_normal_lines:
+    print(line)
+    line = [float(entry) for entry in line.split()]
+    px, py, pz, nx, ny, nz = line
+    point_location = Point_3(px, py, pz)
+    point_normal = Vector_3(nx, ny, nz)
+    points.insert(point_location, point_normal)
+
 print(points.size(), "points read")
 
 print("Detecting planes with region growing (sphere query)")


### PR DESCRIPTION
Personally, I find it very confusing that it is allowed to load points by passing a path to Point_set_3().
Logically (from what I know from Python) I would expect that open("myfile"), which is a data stream, can be passed instead.

Anyway, this rewritten code should work alternatively as far as I understand the documentation of CGAL.
However, I get an segmentation fault when running the example like this.

This commit is therefore a more pythonic example and a bug report at the same time.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)