### PR TITLE
Fix macOS builds that need the CMP0025 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 PROJECT(CGAL-bindings)
 


### PR DESCRIPTION
CGAL itself already requires CMake 3.1