### PR TITLE
Test with CGAL 5.1 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ os:
 env:
   jobs:
   - CGAL_VER=releases/CGAL-5.0
+  - CGAL_VER=v5.1
   - CGAL_VER=master
   global:
   - CGAL_PYTHON_EXAMPLES=examples/python
@@ -32,6 +33,13 @@ matrix:
     python: 3.8
   - os: osx
     env:
+    - CGAL_VER=v5.1
+    - MB_PYTHON_VERSION=3.8
+    osx_image: xcode11.3
+    language: shell
+    python: 3.8
+  - os: osx
+    env:
     - CGAL_VER=master
     - MB_PYTHON_VERSION=3.8
     osx_image: xcode11.3
@@ -46,6 +54,13 @@ matrix:
     python: 3.6
   - os: osx
     env:
+    - CGAL_VER=v5.1
+    - MB_PYTHON_VERSION=3.6
+    osx_image: xcode11.3
+    language: shell
+    python: 3.6
+  - os: osx
+    env:
     - CGAL_VER=master
     - MB_PYTHON_VERSION=3.6
     osx_image: xcode11.3
@@ -54,6 +69,13 @@ matrix:
   - os: osx
     env:
     - CGAL_VER=releases/CGAL-5.0
+    - MB_PYTHON_VERSION=3.7
+    osx_image: xcode11.3
+    language: shell
+    python: 3.7
+  - os: osx
+    env:
+    - CGAL_VER=v5.1
     - MB_PYTHON_VERSION=3.7
     osx_image: xcode11.3
     language: shell


### PR DESCRIPTION
Test with CGAL-5.1 as well. Now the package is tested with:
  - `releases/CGAL-5.0-branch`,
  - `v5.1`, and
  - `master`.
