### PR TITLE
Adding first_intersection / first_intersected_primitive to AABB Tree …

### DIFF
--- a/SWIG_CGAL/AABB_tree/AABB_tree.h
+++ b/SWIG_CGAL/AABB_tree/AABB_tree.h
@@ -167,6 +167,14 @@ public:
       return Optional_primitive_id(Primitive_id(*res));
     return Optional_primitive_id();
   }
+  //first_intersected_primitive
+  Optional_primitive_id first_intersected_primitive(const Ray_3     & query) {
+    boost::optional<typename Tree::Primitive::Id> res=data.first_intersected_primitive(query.get_data());
+    if (res)
+      return Optional_primitive_id(Primitive_id(*res));
+    return Optional_primitive_id();
+  }
+
 //Intersections
   //any_intersection
   Optional_object_and_primitive_id any_intersection(const Segment_3 & query){
@@ -192,6 +200,13 @@ public:
   }
   Optional_object_and_primitive_id any_intersection(const Ray_3     & query){
      boost::optional<typename Tree::template Intersection_and_primitive_id<Ray_3::cpp_base>::Type> res=data.any_intersection(query.get_data());
+    if (res)
+      return Object_and_primitive_id(std::make_pair(Object(res->first), res->second));
+    return Optional_object_and_primitive_id();
+  }
+  //first_intersection
+  Optional_object_and_primitive_id first_intersection(const Ray_3     & query){
+     boost::optional<typename Tree::template Intersection_and_primitive_id<Ray_3::cpp_base>::Type> res=data.first_intersection(query.get_data());
     if (res)
       return Object_and_primitive_id(std::make_pair(Object(res->first), res->second));
     return Optional_object_and_primitive_id();

--- a/examples/python/AABB_triangle_3_example.py
+++ b/examples/python/AABB_triangle_3_example.py
@@ -26,3 +26,16 @@ point_query = Point_3(2.0, 2.0, 2.0)
 closest_point = tree.closest_point(point_query)
 sqd = tree.squared_distance(point_query)
 print("squared distance: ", sqd)
+
+# compute first intersection and first intersected primitive
+first_intersected_primitive = tree.first_intersected_primitive(ray_query)
+print("first intersected primitive index: " + str(first_intersected_primitive.value()))
+first_intersection = tree.first_intersection(ray_query)
+intersected_object = first_intersection.value()[0]
+if intersected_object.is_Point_3():
+	print("intersected point: " + str(intersected_object.get_Point_3()))
+elif intersected_object.is_Segment_3():
+	print("intersected segment: " + str(intersected_object.get_Segment_3()))
+else:
+	print("Unknown intersected point type")
+


### PR DESCRIPTION
…wrapper

See issue created here: https://github.com/CGAL/cgal-swig-bindings/issues/186

first_intersection only supports the "ray" variant, so there are less overloads than the any_intersection.
Updated the python example to also showcase the usage.