### PR TITLE
Triangulation_3: add Python bindings for Delaunay triangulation with vertex info

### DIFF
--- a/SWIG_CGAL/Triangulation_3/CGAL_Triangulation_3.i
+++ b/SWIG_CGAL/Triangulation_3/CGAL_Triangulation_3.i
@@ -69,6 +69,6 @@ SWIG_CGAL_declare_regular_triangulation_3(Regular_triangulation_3,CGAL_RT3)
 
 #ifdef SWIG_CGAL_HAS_Triangulation_3_USER_PACKAGE
 %include "SWIG_CGAL/User_packages/Triangulation_3/extensions.i"
+#endif
 %import "SWIG_CGAL/Triangulation_3/declare_Delaunay_triangulation_3.i"
 SWIG_CGAL_declare_Delaunay_triangulation_3(Delaunay_triangulation_3_with_info, CGAL_DT3_with_info)
-#endif

--- a/SWIG_CGAL/Triangulation_3/CGAL_Triangulation_3.i
+++ b/SWIG_CGAL/Triangulation_3/CGAL_Triangulation_3.i
@@ -26,6 +26,8 @@ SWIG_CGAL_package_common()
   #include <SWIG_CGAL/Triangulation_3/all_includes.h>
   #include <SWIG_CGAL/Common/triple.h>
   #include <SWIG_CGAL/Common/Iterator.h>
+  #include <CGAL/Triangulation_vertex_base_with_info_3.h>
+  #include <CGAL/Delaunay_triangulation_cell_base_3.h>
 %}
 
 %pragma(java) jniclassimports=%{import CGAL.Kernel.Point_3; import CGAL.Kernel.Line_3; import CGAL.Kernel.Weighted_point_3; import CGAL.Kernel.Triangle_3; import CGAL.Kernel.Segment_3; import CGAL.Kernel.Tetrahedron_3; import CGAL.Kernel.Ref_int; import java.util.Iterator; import java.util.Collection;%}
@@ -67,4 +69,6 @@ SWIG_CGAL_declare_regular_triangulation_3(Regular_triangulation_3,CGAL_RT3)
 
 #ifdef SWIG_CGAL_HAS_Triangulation_3_USER_PACKAGE
 %include "SWIG_CGAL/User_packages/Triangulation_3/extensions.i"
+%import "SWIG_CGAL/Triangulation_3/declare_Delaunay_triangulation_3.i"
+SWIG_CGAL_declare_Delaunay_triangulation_3(Delaunay_triangulation_3_with_info, CGAL_DT3_with_info)
 #endif

--- a/SWIG_CGAL/Triangulation_3/typedefs.h
+++ b/SWIG_CGAL/Triangulation_3/typedefs.h
@@ -11,6 +11,14 @@
 #include <CGAL/Regular_triangulation_3.h>
 
 #include <CGAL/Delaunay_triangulation_3.h>
+#include <CGAL/Triangulation_vertex_base_with_info_3.h>
+#include <CGAL/Delaunay_triangulation_cell_base_3.h>
+#include <CGAL/Triangulation_data_structure_3.h>
+
+typedef CGAL::Triangulation_vertex_base_with_info_3<double, EPIC_Kernel>  Vb_with_info;
+typedef CGAL::Delaunay_triangulation_cell_base_3<EPIC_Kernel>             Cb;
+typedef CGAL::Triangulation_data_structure_3<Vb_with_info, Cb>            Tds_with_info;
+typedef CGAL::Delaunay_triangulation_3<EPIC_Kernel, Tds_with_info>        CGAL_DT3_with_info;
 
 typedef CGAL::Triangulation_3<EPIC_Kernel>                              CGAL_T3;
 typedef CGAL::Delaunay_triangulation_3<EPIC_Kernel>                     CGAL_DT3;

--- a/examples/python/test_triangulation_3_with_info.py
+++ b/examples/python/test_triangulation_3_with_info.py
@@ -1,0 +1,14 @@
+from CGAL.CGAL_Triangulation_3 import Delaunay_triangulation_3_with_info
+from CGAL.CGAL_Kernel import Point_3
+
+T = Delaunay_triangulation_3_with_info()
+T.insert(Point_3(0, 0, 0))
+T.insert(Point_3(1, 0, 0))
+T.insert(Point_3(0, 1, 0))
+T.insert(Point_3(0, 0, 1))
+T.insert(Point_3(2, 2, 2))
+T.insert(Point_3(-1, 0, 1))
+
+print(f"Number of vertices: {T.number_of_vertices()}")
+assert T.number_of_vertices() == 6
+print("Test passed!")


### PR DESCRIPTION
**Description:**

Fixes #288

## Problem
Users cannot attach custom data (e.g. float/double values) to 
triangulation vertices from Python because these classes were 
missing from the SWIG interface:
- Triangulation_vertex_base_with_info_3
- Delaunay_triangulation_cell_base_3

## Solution
- Added includes and typedefs in `typedefs.h` for a new
  `CGAL_DT3_with_info` type using `double` as vertex info
- Exposed `Delaunay_triangulation_3_with_info` class in
  `CGAL_Triangulation_3.i` outside the USER_PACKAGE ifdef block
- Added Python example `test_triangulation_3_with_info.py`
  with a working test (6 vertices inserted and verified)

## Testing
Tested locally — build succeeds and test passes:

Number of vertices: 6
Test passed!
